### PR TITLE
Take into account precision option

### DIFF
--- a/lib/helpers/DFHelper.js
+++ b/lib/helpers/DFHelper.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var
-  _ = require('underscore');
+  _ = require('underscore'),
+  sprintf = require('sprintf');
 
 function DFHelper() {}
 
@@ -15,6 +16,7 @@ _.extend(DFHelper, {
       multiplier = DFHelper.getMultiplierByPrefix(options.prefixMultiplier),
       isDisplayPrefixMultiplier =  !! options.isDisplayPrefixMultiplier,
       displayedPrefixMultiplier = isDisplayPrefixMultiplier ? options.prefixMultiplier : null,
+      precision = ((options.precision !== undefined) && (options.precision !== null) && _.isNumber(options.precision)) ? options.precision : 2,
 
       format = DFHelper.format,
       response = _(stdout
@@ -44,11 +46,11 @@ _.extend(DFHelper, {
 
             var
               filesystem = columns[0],
-              size = format(columns[1], multiplier, 2, 
+              size = format(columns[1], multiplier, precision,
                 displayedPrefixMultiplier),
-              used = format(columns[2], multiplier, 2, 
+              used = format(columns[2], multiplier, precision,
                 displayedPrefixMultiplier),
-              available = format(columns[3], multiplier, 2, 
+              available = format(columns[3], multiplier, precision,
                 displayedPrefixMultiplier),
               capacity = format(columns[4], 0.01),
               mount = _.rest(columns, 5).join(' ');
@@ -68,13 +70,13 @@ _.extend(DFHelper, {
   format: function (s, multiplier, precision, displayedPrefixMultiplier) {
     multiplier = multiplier || 1;
 
+    precision = ((precision !== undefined) && (precision !== null) && _.isNumber(precision)) ? precision : 2;
+
     var
       tmp = parseInt(s, 10) * multiplier,
-      amount = Math.pow(10, precision);
+      formatstr = "%."+precision+"f";
 
-    if (precision && _.isNumber(precision)) {
-      tmp = Math.round(tmp * amount) / amount;
-    }
+    tmp = sprintf(formatstr, tmp);
 
     if (displayedPrefixMultiplier) {
       tmp = tmp+displayedPrefixMultiplier;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "author": "Adriano Di Giovanni <me@adrianodigiovanni.com> (http://adrianodigiovanni.com/)",
   "license": "MIT",
   "dependencies": {
-    "underscore": "^1.6.0"
+    "underscore": "^1.6.0",
+    "sprintf": "^0.1.5"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Hi there,

it seems that the precision option is not taken into account. I tried different values but the result was the same. 
This pull request fixes the problem. Sprintf module is used for that purpose. 

I hope you release it.

Thanks,
Giannis Kosmas