### PR TITLE
don't break when stderr is used

### DIFF
--- a/lib/df.js
+++ b/lib/df.js
@@ -18,16 +18,12 @@
 
     exec(cmd, function (error, stdout, stderr) {
 
-      if (error) { return callback(error); }
-
-      if (stderr) {
-        return callback(new Error(stderr));
-      }
+      if (error) { error.message = stderr; }
 
       var
         response = DFHelper.parse(stdout, options);
 
-        callback(null, response);
+        callback(error || stderr, response);
     });
   }
 


### PR DESCRIPTION
`df` printing to stderr does not mean the command failed.

for example, on heroku, using `df` fails:
```shell
$ df; echo $?
df: cannot read table of mounted file systems: No such file or directory
1
```
but using `df /app` works with a warning:
```shell
$ df /app; echo $?
df: Warning: cannot read table of mounted file systems: No such file or directory
Filesystem           1K-blocks Used Available Use% Mounted on
-                        12345  123 1234      123% /app
0
```

This change first checks if there is an error, and then sets the error's message to whatever stderr is.
It will always call back with the error or stderr only, and with the parsed info from stdout.
However, it will always try to parse, even if stderr is used or an error occured

That makes it possible to use node-df on systems like heroku where df prints warnings to stderr, but works anyway