### PR TITLE
Prevent shell injection with escaping commande

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 var exec = require('child_process').exec
 var parse = require('./parse')
+var shellescape = require('shell-escape');
 
 module.exports = function df(aOptions, aCallback) {
     var options
@@ -38,7 +39,7 @@ module.exports = function df(aOptions, aCallback) {
         command += ' ' + options.file
     }
 
-    exec(command, function(err, stdout, stderr) {
+    exec(shellescape(command), function(err, stdout, stderr) {
         if (err) {
             callback(err)
             return

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
     "name": "node-df",
     "version": "0.1.4",
-    "description":
-        "A cross-platform Node.js wrapper around the standard Unix computer program, df.",
+    "description": "A cross-platform Node.js wrapper around the standard Unix computer program, df.",
     "main": "lib/index.js",
     "scripts": {
         "precommit": "lint-staged",
@@ -12,6 +11,7 @@
     "author": "Adriano Di Giovanni <me@adrianodigiovanni.com> (http://adrianodigiovanni.com/)",
     "license": "MIT",
     "dependencies": {
+        "shell-escape": "^0.2.0",
         "underscore": "^1.6.0"
     },
     "devDependencies": {
@@ -33,13 +33,25 @@
         "type": "git",
         "url": "https://github.com/adriano-di-giovanni/node-df.git"
     },
-    "keywords": ["node", "df", "disk", "free", "diskfree"],
+    "keywords": [
+        "node",
+        "df",
+        "disk",
+        "free",
+        "diskfree"
+    ],
     "bugs": {
         "url": "https://github.com/adriano-di-giovanni/node-df/issues"
     },
     "lint-staged": {
-        "*.js": ["eslint --fix", "git add"],
-        "*.json": ["prettier --write", "git add"]
+        "*.js": [
+            "eslint --fix",
+            "git add"
+        ],
+        "*.json": [
+            "prettier --write",
+            "git add"
+        ]
     },
     "homepage": "https://github.com/adriano-di-giovanni/node-df"
 }


### PR DESCRIPTION
Fix CVE issue https://github.com/advisories/GHSA-wp7m-mrvf-599c

Add new dependency : https://www.npmjs.com/package/shell-escape

! Not tested !